### PR TITLE
fix: lower gpu node cpu-request to allow scheduling

### DIFF
--- a/frontend/src/app/resource-form/resource-form.component.ts
+++ b/frontend/src/app/resource-form/resource-form.component.ts
@@ -112,7 +112,7 @@ export class ResourceFormComponent implements OnInit, OnDestroy {
       this.readonlySpecs = false;
     } else {
       this.readonlySpecs = true;
-      this.formCtrl.get("cpu").setValue("5");
+      this.formCtrl.get("cpu").setValue("4");
       this.formCtrl.get("memory").setValue("96Gi");
     }
   }

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -72,7 +72,7 @@
     "optNone": "None",
     "lblGpuVendor": "GPU Vendor",
     "errorGpuVendorRequired": "You must also specify the GPU Vendor for the assigned GPUs",
-    "specsWarningMessage": "Selecting 1 GPU will automatically set 5 CPUs and 96Gi of memory."
+    "specsWarningMessage": "Selecting 1 GPU will automatically set 4 CPUs and 96Gi of memory."
   },
   "formImage": {
     "h3Image": "Image",

--- a/frontend/src/assets/i18n/fr.json
+++ b/frontend/src/assets/i18n/fr.json
@@ -72,7 +72,7 @@
     "optNone": "Aucun",
     "lblGpuVendor": "Vendeur de GPU",
     "errorGpuVendorRequired": "Vous devez spécifier le vendeur des GPUs assignés",
-    "specsWarningMessage": "La sélection de 1 GPU définira automatiquement 5 processeurs et 96Gi de la mémoire."
+    "specsWarningMessage": "La sélection de 1 GPU définira automatiquement 4 processeurs et 96Gi de la mémoire."
 
   },
   "formImage": {


### PR DESCRIPTION
My colleague's GPU image was not able to be scheduled, it appears because of the CPU limits. After doing a few `kubectl edit`s on his image, adjusting the cpu and memory, I found that reducing the CPU without touching the memory was enough to get the image scheduled.