### PR TITLE
feat: Add image help text link

### DIFF
--- a/frontend/common/kubeflow-common-lib/projects/kubeflow/src/lib/form/form.module.ts
+++ b/frontend/common/kubeflow-common-lib/projects/kubeflow/src/lib/form/form.module.ts
@@ -16,6 +16,7 @@ import {
 } from '@angular/material';
 
 import { FormSectionComponent } from './section/section.component';
+import { FormSectionImageComponent } from './section-image/section.image.component';
 
 import { NameNamespaceInputsComponent } from './name-namespace-inputs/name-namespace-inputs.component';
 import { NameInputComponent } from './name-namespace-inputs/name-input/name-input.component';
@@ -30,6 +31,7 @@ import { StepInfoComponent } from './step-info/step-info.component';
 @NgModule({
   declarations: [
     FormSectionComponent,
+    FormSectionImageComponent,
     NameNamespaceInputsComponent,
     NameInputComponent,
     PositiveNumberInputComponent,
@@ -53,6 +55,7 @@ import { StepInfoComponent } from './step-info/step-info.component';
   ],
   exports: [
     FormSectionComponent,
+    FormSectionImageComponent,
     NameNamespaceInputsComponent,
     NameInputComponent,
     PositiveNumberInputComponent,

--- a/frontend/common/kubeflow-common-lib/projects/kubeflow/src/lib/form/section-image/section.image.component.html
+++ b/frontend/common/kubeflow-common-lib/projects/kubeflow/src/lib/form/section-image/section.image.component.html
@@ -1,0 +1,7 @@
+<div class="form--section-bottom">
+  <h3><lib-icon *ngIf="icon" [icon]="icon"></lib-icon>{{ title }}</h3>
+  <p>{{ text }}</p>
+  <a href="{{ link }}">{{ linkText }}</a>
+  <p *ngIf="readOnly">*The cluster admin has disabled setting this section!</p>
+  <ng-content></ng-content>
+</div>

--- a/frontend/common/kubeflow-common-lib/projects/kubeflow/src/lib/form/section-image/section.image.component.scss
+++ b/frontend/common/kubeflow-common-lib/projects/kubeflow/src/lib/form/section-image/section.image.component.scss
@@ -1,0 +1,23 @@
+.wide {
+  width: 100%;
+}
+
+h3,
+p {
+  margin-block-start: 0.2rem;
+  color: rgba(0, 0, 0, 0.54);
+}
+
+.lib-icon {
+  margin-right: 0.3rem;
+}
+
+// The following two rules are for adding bottom margin
+// inside of a form section
+.form--section-bottom {
+  margin-bottom: 0.5em;
+}
+
+.form--section-bottom > button {
+  margin-bottom: 0.5em;
+}

--- a/frontend/common/kubeflow-common-lib/projects/kubeflow/src/lib/form/section-image/section.image.component.spec.ts
+++ b/frontend/common/kubeflow-common-lib/projects/kubeflow/src/lib/form/section-image/section.image.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FormSectionImageComponent } from './section.image.component';
+import { FormModule } from '../form.module';
+
+describe('FormSectionImageComponent', () => {
+  let component: FormSectionImageComponent;
+  let fixture: ComponentFixture<FormSectionImageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [FormModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FormSectionImageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/common/kubeflow-common-lib/projects/kubeflow/src/lib/form/section-image/section.image.component.ts
+++ b/frontend/common/kubeflow-common-lib/projects/kubeflow/src/lib/form/section-image/section.image.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+@Component({
+  selector: 'lib-form-section-image',
+  templateUrl: './section.image.component.html',
+  styleUrls: ['./section.image.component.scss'],
+})
+export class FormSectionImageComponent implements OnInit {
+  @Input()
+  title: string;
+
+  @Input()
+  text: string;
+
+  @Input()
+  link: string;
+
+  @Input()
+  linkText: string;
+
+  @Input()
+  readOnly: string;
+
+  @Input()
+  style: string;
+
+  @Input()
+  icon: string;
+
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/frontend/jupyter/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -1,7 +1,9 @@
-<lib-form-section
+<lib-form-section-image
   title="Image"
-  text="A started Jupyter Docker Image with a baseline deployment and typical
-  ML packages"
+  text="Select the base software you want installed in your server. If you 
+  choose a custom image, it must be available in the DAaaS container registry."
+  link="https://statcan.github.io/daaas/en/1-Experiments/Selecting-an-Image"
+  linkText="Here's some more information to help you select an image for your requirements."
   icon="fa:fab:docker"
 >
   <div class="flex-column">
@@ -128,4 +130,4 @@
       </mat-form-field>
     </div>
   </lib-advanced-options>
-</lib-form-section>
+</lib-form-section-image>


### PR DESCRIPTION
Closes https://github.com/StatCan/jupyter-apis/issues/69

I decided to create a new component so we can keep the link displayed correctly.