### PR TITLE
feat: add KF_LANG env variable

### DIFF
--- a/frontend/jupyter/src/app/pages/form/form-default/form-advanced-options/form-advanced-options.component.html
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-advanced-options/form-advanced-options.component.html
@@ -3,7 +3,19 @@
   text="Other possible settings to be applied to the Notebook Server."
   icon="fa:fas:cogs"
 >
+  <!--Enable Shared Memory-->
   <mat-slide-toggle [formControl]="parentForm.get('shm')">
     Enable Shared Memory
   </mat-slide-toggle>
+  
+  <!--Select System Language-->
+  <mat-form-field class="wide column" appearance="outline">
+    <mat-label>System Language</mat-label>
+    <mat-select [formControl]="parentForm.get('language')">
+      <mat-option *ngFor="let v of languageList" [value]="v.id">
+        {{ v.label }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+  
 </lib-form-section>

--- a/frontend/jupyter/src/app/pages/form/form-default/form-advanced-options/form-advanced-options.component.ts
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-advanced-options/form-advanced-options.component.ts
@@ -8,6 +8,10 @@ import { FormGroup } from '@angular/forms';
 })
 export class FormAdvancedOptionsComponent implements OnInit {
   @Input() parentForm: FormGroup;
+  languageList = [
+    {'id':'en', 'label':'English'},
+    {'id':'fr', 'label':'French'}    
+  ];
 
   constructor() {}
 

--- a/frontend/jupyter/src/app/pages/form/form-default/utils.ts
+++ b/frontend/jupyter/src/app/pages/form/form-default/utils.ts
@@ -41,6 +41,7 @@ export function getFormDefaults(): FormGroup {
     datavols: fb.array([]),
     shm: [true, []],
     configurations: [[], []],
+    language: ['', [Validators.required]],
   });
 }
 


### PR DESCRIPTION
Implements changes introduced by [feat: Add env variable to set language of the notebook server](https://github.com/StatCan/jupyter-apis/pull/48/commits/83af67391be036d279453a649bb5b6a9f08a985b) to be compatible with KF 1.3 front end. EXCLUDES ANY i18n which will be addressed in https://github.com/StatCan/jupyter-apis/issues/73

Closes #74 