### PR TITLE
feat(frontend):add validations customizations(name,cpu,ram)

### DIFF
--- a/frontend/common/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/resource-table.component.scss
+++ b/frontend/common/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/resource-table.component.scss
@@ -30,3 +30,18 @@ mat-toolbar {
 .mat-icon {
   line-height: 0.85;
 }
+
+th,
+td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+td.mat-column-image,
+td.mat-column-name {
+  max-width: 200px;
+}
+
+td.mat-column-cpu {
+  width: 40px;
+}

--- a/frontend/jupyter/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html
@@ -4,24 +4,31 @@
     For CPU-intensive workloads, you can choose more than 1 CPU (e.g. 1.5)."
   icon="fa:fas:microchip"
 >
-  <div class="row">
+  <div class="row" [formGroup]="parentForm">
     <!--CPU-->
-    <lib-positive-number-input
-      class="column"
-      min="0.1"
-      step="0.1"
-      [sizeControl]="parentForm.get('cpu')"
-      label="Requested CPUs"
-    ></lib-positive-number-input>
+      <mat-form-field appearance="outline" class="column">
+        <mat-label>Requested CPUs</mat-label>
+        <input
+          label="Requested CPUs"
+          [attr.disabled]="readonlySpecs ? '' : null"
+          matInput
+          formControlName="cpu"
+          [errorStateMatcher]="parentErrorKeysErrorStateMatcher('maxCpu')"
+        />
+        <mat-error>{{cpuErrorMessage()}}</mat-error>
+      </mat-form-field>
 
     <!--RAM-->
-    <lib-positive-number-input
-      class="column"
-      min="0.1"
-      step="0.1"
-      [sizeControl]="parentForm.get('memory')"
-      label="Requested memory in Gi"
-    ></lib-positive-number-input>
+      <mat-form-field appearance="outline" class="column">
+        <mat-label>Requested memory in Gi</mat-label>
+        <input
+          [attr.disabled]="readonlySpecs ? '' : null"
+          matInput
+          formControlName="memory"
+          [errorStateMatcher]="parentErrorKeysErrorStateMatcher('maxRam')"
+        />
+        <mat-error>{{getRAMError()}}</mat-error>
+      </mat-form-field>
   </div>
   <lib-advanced-options>
     <div class="row">

--- a/frontend/jupyter/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.ts
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.ts
@@ -1,6 +1,31 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, AbstractControl, Validators, ValidatorFn, ControlContainer, FormControl, FormGroupDirective, NgForm, ValidationErrors } from '@angular/forms';
 
+const MAX_FOR_GPU: ReadonlyMap<number, MaxResourceSpec> = new Map([
+  [0, {cpu: 15, ram: 48}],
+  [1, {cpu: 5, ram: 96}]
+]);
+type MaxResourceSpec = {cpu: number; ram: number};
+
+function resourcesValidator(): ValidatorFn {
+  return function (control: AbstractControl): ValidationErrors | null {
+    const gpuNumValue = control.get("gpus").get("num").value;
+    const gpu = gpuNumValue === "none" ? 0 : parseInt(gpuNumValue, 10) || 0;
+    const cpu = parseFloat(control.get("cpu").value);
+    const ram = parseFloat(control.get("memory").value);
+    const errors = {};
+    const max = MAX_FOR_GPU.get(gpu);
+    if (gpu == 0) {
+      if (cpu > max.cpu) {
+        errors["maxCpu"] = {max: max.cpu, gpu};
+      }
+      if (ram > max.ram) {
+        errors["maxRam"] = {max: max.ram, gpu};
+      }
+    }
+    return Object.entries(errors).length > 0 ? errors : null;
+  };
+}
 @Component({
   selector: 'app-form-cpu-ram',
   templateUrl: './form-cpu-ram.component.html',
@@ -12,38 +37,106 @@ export class FormCpuRamComponent implements OnInit {
   @Input() readonlyMemory: boolean;
   @Input() cpuLimitFactor: string;
   @Input() memoryLimitFactor: string;
+  @Input() readonlySpecs: boolean;
 
   constructor() {}
 
   ngOnInit() {
-    this.parentForm.get('cpu').valueChanges.subscribe(val => {
-      //set cpu limit when value of the cpu request changes
-      if (this.cpuLimitFactor !== null) {
-        this.parentForm
-          .get('cpuLimit')
-          .setValue(
-            (
-              parseFloat(this.cpuLimitFactor) * this.parentForm.get('cpu').value
-            ).toFixed(1),
-          );
-      }
-    });
-    this.parentForm.get('memory').valueChanges.subscribe(val => {
-      //set memory limit when value of the memory request changes
-      if (this.memoryLimitFactor !== null) {
-        this.parentForm
-          .get('memoryLimit')
-          .setValue(
-            (
-              parseFloat(this.memoryLimitFactor) *
-              this.parentForm.get('memory').value
-            ).toFixed(1),
-          );
-      }
-    });
+    this.parentForm
+      .get('cpu')
+      .setValidators([Validators.required, Validators.pattern(/^[0-9]+([.][0-9]+)?$/), Validators.min(0.5), this.maxCPUValidator()]);
+    this.parentForm
+      .get('memory')
+      .setValidators([Validators.required, Validators.pattern(/^[0-9]+([.][0-9]+)?$/), Validators.min(1), this.maxMemoryValidator()]);
+      this.parentForm.setValidators(resourcesValidator());
+
+      this.parentForm.get('cpu').valueChanges.subscribe(val => {
+        //set cpu limit when value of the cpu request changes
+        if (this.cpuLimitFactor !== null) {
+          this.parentForm
+            .get('cpuLimit')
+            .setValue(
+              (
+                parseFloat(this.cpuLimitFactor) * this.parentForm.get('cpu').value
+              ).toFixed(1),
+            );
+        }
+      });
+      this.parentForm.get('memory').valueChanges.subscribe(val => {
+        //set memory limit when value of the memory request changes
+        if (this.memoryLimitFactor !== null) {
+          this.parentForm
+            .get('memoryLimit')
+            .setValue(
+              (
+                parseFloat(this.memoryLimitFactor) *
+                this.parentForm.get('memory').value
+              ).toFixed(1),
+            );
+
+        }
+      });
   }
 
-  getCPUError() {}
+  private maxCPUValidator(): ValidatorFn
+  {
+    return (control: AbstractControl): { [key: string]: any} | null => {
+      var max: number;
+      const gpus = this.parentForm.get('gpus').get('num').value;
+      gpus == 'none' ? max = 15 : max = 5;
+      return control.value>max ? { maxCPU: true } : null
+    }
+  }
 
-  getRAMError() {}
+  private maxMemoryValidator(): ValidatorFn
+  {
+    return (control: AbstractControl): { [key: string]: any} | null => {
+      var max: number;
+      const gpus = this.parentForm.get('gpus').get('num').value;
+      gpus == 'none' ? max = 48 : max = 96;
+      return control.value>max ? { maxMemory: true } : null
+    }
+  }
+
+  parentErrorKeysErrorStateMatcher(keys: string | string[]) {
+    const arrKeys = ([] as string[]).concat(keys);
+    return {
+      isErrorState(
+        control: FormControl,
+        form: FormGroupDirective | NgForm
+      ): boolean {
+        return (
+          (control.dirty && control.invalid) ||
+          (form.dirty && arrKeys.some(key => form.hasError(key)))
+        );
+      }
+    };
+  }
+
+  cpuErrorMessage() {
+    let e: any;
+    const errs = this.parentForm.get("cpu").errors || {};
+    if (errs.required)
+      return "Specify number of CPUs";
+    if (errs.pattern) "Must be a number";
+    if ((e = errs.min))
+      return `Specify at least ${e.min} CPUs`;
+    if (this.parentForm.hasError("maxCpu")) {
+      e = this.parentForm.errors.maxCpu;
+      return `Can't exceed ${e.max} CPUs`;
+    }
+  }
+
+  getRAMError() {
+    let e: any;
+    const errs = this.parentForm.get("memory").errors || {};
+    if (errs.required || errs.pattern)
+    return "Specify amount of memory (e.g. 2Gi)";
+    if ((e = errs.min))
+      return `Specify at least ${e.min}Gi of memory`;
+    if (this.parentForm.hasError("maxRam")) {
+      e = this.parentForm.errors.maxRam;
+      return `Can't exceed ${e.max}Gi of memory`;
+    }
+  }
 }

--- a/frontend/jupyter/src/app/pages/form/form-default/form-data-volumes/form-data-volumes.component.html
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-data-volumes/form-data-volumes.component.html
@@ -25,6 +25,7 @@
         [pvcs]="pvcs"
         [ephemeral]="false"
         [defaultStorageClass]="defaultStorageClass"
+        [sizes]="['4Gi', '8Gi', '16Gi', '32Gi', '64Gi', '128Gi', '256Gi', '512Gi']"
       >
       </app-volume>
 

--- a/frontend/jupyter/src/app/pages/form/form-default/form-default.component.html
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-default.component.html
@@ -20,11 +20,13 @@
           [readonlyMemory]="config?.memory?.readOnly"
           [cpuLimitFactor]="config?.cpu?.limitFactor"
           [memoryLimitFactor]="config?.memory?.limitFactor"
+          [readonlySpecs]="readonlySpecs"
         ></app-form-cpu-ram>
 
         <app-form-gpus
           [parentForm]="formCtrl"
           [vendors]="config?.gpus?.value.vendors"
+          (gpuValueEvent)="checkGPU($event)"
         ></app-form-gpus>
 
         <app-form-workspace-volume

--- a/frontend/jupyter/src/app/pages/form/form-default/form-default.component.ts
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-default.component.ts
@@ -34,6 +34,8 @@ export class FormDefaultComponent implements OnInit, OnDestroy {
 
   subscriptions = new Subscription();
 
+  readonlySpecs: boolean;
+
   constructor(
     public namespaceService: NamespaceService,
     public backend: JWABackendService,
@@ -165,6 +167,16 @@ export class FormDefaultComponent implements OnInit, OnDestroy {
       this.router.navigate(['/']);
     });
   }
+    // Automatically set values of CPU and Memory if GPU is 1
+    checkGPU(gpu: string) {
+      if (gpu == "none") {
+        this.readonlySpecs = false;
+      } else {
+        this.readonlySpecs = true;
+        this.formCtrl.get("cpu").setValue("4");
+        this.formCtrl.get("memory").setValue("96");
+      }
+    }
 
   onCancel() {
     this.router.navigate(['/']);

--- a/frontend/jupyter/src/app/pages/form/form-default/form-gpus/form-gpus.component.html
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-gpus/form-gpus.component.html
@@ -8,12 +8,13 @@
     <!--GPUs Number-->
     <mat-form-field class="column" appearance="outline">
       <mat-label>Number of GPUs</mat-label>
-      <mat-select matNativeControl formControlName="num">
+      <mat-select [(value)]="selected" matNativeControl formControlName="num">
         <mat-option value="none">None</mat-option>
         <mat-option *ngFor="let v of gpusCount" [value]="v">
           {{ v }}
         </mat-option>
       </mat-select>
+      <mat-hint>{{ message }}</mat-hint>
     </mat-form-field>
 
     <!--GPUs Vendor-->

--- a/frontend/jupyter/src/app/pages/form/form-default/form-gpus/form-gpus.component.ts
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-gpus/form-gpus.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { FormGroup, ValidatorFn, AbstractControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { GPUVendor } from 'src/app/types';
@@ -12,13 +12,15 @@ import { JWABackendService } from 'src/app/services/backend.service';
 export class FormGpusComponent implements OnInit {
   @Input() parentForm: FormGroup;
   @Input() vendors: GPUVendor[] = [];
+  @Output() gpuValueEvent = new EventEmitter<string>();
 
   private gpuCtrl: FormGroup;
   public installedVendors = new Set<string>();
-
+  public selected = 'none';
   subscriptions = new Subscription();
   maxGPUs = 16;
-  gpusCount = ['1', '2', '4', '8'];
+  gpusCount = ['1'];
+  message: string;
 
   constructor(public backend: JWABackendService) {}
 
@@ -34,10 +36,13 @@ export class FormGpusComponent implements OnInit {
     this.subscriptions.add(
       this.gpuCtrl.get('num').valueChanges.subscribe((n: string) => {
         if (n === 'none') {
+          this.message = "";
           this.gpuCtrl.get('vendor').disable();
         } else {
+          this.message = "Selecting 1 GPU will automatically set 4 CPUs and 96Gi of memory."
           this.gpuCtrl.get('vendor').enable();
         }
+        this.gpuValueEvent.emit(n)
       }),
     );
 

--- a/frontend/jupyter/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -120,7 +120,7 @@
     <div class="row">
       <mat-form-field class="column" appearance="outline">
         <mat-label>Image pull policy</mat-label>
-        <mat-select [formControl]="parentForm.get('imagePullPolicy')">
+        <mat-select [(value)]="selected" [formControl]="parentForm.get('imagePullPolicy')">
           <mat-option value="Always">Always</mat-option>
           <mat-option value="IfNotPresent">IfNotPresent</mat-option>
           <mat-option value="Never">Never</mat-option>

--- a/frontend/jupyter/src/app/pages/form/form-default/form-image/form-image.component.ts
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-image/form-image.component.ts
@@ -16,7 +16,7 @@ export class FormImageComponent implements OnInit, OnDestroy {
   @Input() imagesGroupOne: string[];
   @Input() imagesGroupTwo: string[];
   @Input() allowCustomImage: boolean;
-
+  selected = 'IfNotPresent';
   subs = new Subscription();
 
   constructor(iconRegistry: MatIconRegistry, sanitizer: DomSanitizer) {

--- a/frontend/jupyter/src/app/pages/form/form-default/form-workspace-volume/form-workspace-volume.component.html
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-workspace-volume/form-workspace-volume.component.html
@@ -17,6 +17,7 @@
       [ephemeral]="parentForm.value.noWorkspace"
       [namespace]="parentForm.value.namespace"
       [defaultStorageClass]="defaultStorageClass"
+      [sizes]="['4Gi', '8Gi', '16Gi', '32Gi']"
     >
     </app-volume>
   </div>

--- a/frontend/jupyter/src/app/pages/form/form-default/utils.ts
+++ b/frontend/jupyter/src/app/pages/form/form-default/utils.ts
@@ -102,7 +102,7 @@ export function addDataVolume(
         value: '{notebook-name}-vol-' + (l + 1),
       },
       size: {
-        value: '5',
+        value: '16',
       },
       mountPath: {
         value: '/home/jovyan/{volume-name}',

--- a/frontend/jupyter/src/app/pages/form/form-default/volume/volume.component.html
+++ b/frontend/jupyter/src/app/pages/form/form-default/volume/volume.component.html
@@ -15,19 +15,20 @@
   ></lib-name-input>
 
   <!-- Size Input -->
-  <lib-positive-number-input
-    id="size"
-    class="column"
-    min="1"
-    step="1"
-    [sizeControl]="volume.get('size')"
-    label="Size in Gi"
-  ></lib-positive-number-input>
+  <!--upstream had users choosing via input, change back to pre-populated dropdown -->
+  <mat-form-field appearance="outline" id="size">
+    <mat-label>Size</mat-label>
+    <mat-select formControlName="size">
+      <mat-option *ngFor="let sizeOptions of sizes" [value]="sizeOptions">{{
+        sizeOptions
+      }}</mat-option>
+    </mat-select>
+  </mat-form-field>
 
   <!-- Mode Input -->
   <mat-form-field class="column" appearance="outline" id="mode">
     <mat-label>Mode</mat-label>
-    <mat-select formControlName="mode">
+    <mat-select [(value)]="selected" formControlName="mode">
       <mat-option value="ReadWriteOnce">ReadWriteOnce</mat-option>
       <mat-option value="ReadOnlyMany">ReadOnlyMany</mat-option>
       <mat-option value="ReadWriteMany">ReadWriteMany</mat-option>

--- a/frontend/jupyter/src/app/pages/form/form-default/volume/volume.component.ts
+++ b/frontend/jupyter/src/app/pages/form/form-default/volume/volume.component.ts
@@ -17,10 +17,11 @@ export class VolumeComponent implements OnInit, OnDestroy {
   existingPVCs: Set<string> = new Set();
 
   subscriptions = new Subscription();
-
+  selected="ReadWriteOnce"
   // ----- @Input Parameters -----
   @Input() volume: FormGroup;
   @Input() namespace: string;
+  @Input() sizes: Set<string>;
 
   @Input()
   get notebookName() {


### PR DESCRIPTION
closes #76, #80
Added validation for Cpu, Ram
Output tested:
(No longer need to add Gi for Ram)
![image](https://user-images.githubusercontent.com/28408586/155569675-cdc862a6-10ff-432a-9da6-19affb60f70d.png)
When 1 Gpu selected, Cpu and Ram disabled and set to 4 and 96
![image](https://user-images.githubusercontent.com/28408586/155569710-b4ebf740-1ed1-4b41-86d3-a8f33bba498c.png)
![image](https://user-images.githubusercontent.com/28408586/155569736-eddbe198-9403-4074-a089-44798b3176cb.png)
