### PR TITLE
feat: non-employee-rbac

### DIFF
--- a/samples/spawner_ui_config.yaml
+++ b/samples/spawner_ui_config.yaml
@@ -51,7 +51,7 @@ spawnerFormDefaults:
     # the Istio rewrite for containers that host their web UI at `/`
     enabledCondition:
       labels:
-        state.aaw.statcan.gc.ca/non-employee-users: false
+        state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: false
     disabledMessage:
       en: "SAS is unavailable while non-employees have access to this profile."
       fr: "SAS n'est pas disponible lorsque des non-employés ont accès à ce profil."


### PR DESCRIPTION
# Description

Change `employee-only-features` label to `state.aaw.statcan.gc.ca/exists-non-sas-notebook-user` in `spawner_ui_config.yaml` to grey out SAS icon if there exists a user in the namespace without the SAS notebook capability.