### PR TITLE
set(sizeNum): default to 16

### DIFF
--- a/frontend/jupyter/src/app/pages/form/form-default/volume/new/size/size.component.ts
+++ b/frontend/jupyter/src/app/pages/form/form-default/volume/new/size/size.component.ts
@@ -33,6 +33,7 @@ export class VolumeSizeComponent implements OnInit {
   ngOnInit(): void {
     this.sizeNum.setValue(this.parseK8sGiSizeToInt(this.sizeCtrl.value));
     this.sizeCtrl.setValue(`${this.sizeNum.value}Gi`);
+    this.sizeNum.setValue("16");
 
     this.sizeNum.valueChanges.subscribe(size => {
       this.sizeCtrl.setValue(`${size}Gi`, { emitEvent: false });


### PR DESCRIPTION
closes #108 

### Description:
Setting `this.sizeNum.setValue("16");` in `ngOnInit()` of `size.component.ts` sets the default value in `mat-select` of `size.component.html` to `16`.

### Screenshot:
![image](https://user-images.githubusercontent.com/8212170/197257664-bdb6e7c4-371c-4878-81f5-eb232506f780.png)

### Reference:
- https://stackoverflow.com/questions/50650790/set-default-option-in-mat-select