### PR TITLE
update(form-default): return to usable state.

### DIFF
--- a/frontend/jupyter/src/app/pages/form/form-default/form-default.component.ts
+++ b/frontend/jupyter/src/app/pages/form/form-default/form-default.component.ts
@@ -191,6 +191,8 @@ export class FormDefaultComponent implements OnInit, OnDestroy {
   checkGPU(gpu: string) {
     if (gpu == "none") {
       this.readonlySpecs = false;
+      this.formCtrl.get("cpu").setValue("1");
+      this.formCtrl.get("memory").setValue("4");
     } else {
       this.readonlySpecs = true;
       this.formCtrl.get("cpu").setValue("4");


### PR DESCRIPTION
When the user toggles the GPU settings, the CPU and memory settings now returns to 1 CPU and 4 gigabyes of ram, which is a usable state.

Closes #178.