### PR TITLE
added style to fix server image button bug

### DIFF
--- a/frontend/jupyter/src/styles.scss
+++ b/frontend/jupyter/src/styles.scss
@@ -13,3 +13,12 @@ mat-form-field {
     margin-top: -0.6em;
   }
 }
+
+// AAW: to fix server image button group
+.server-type-wrapper .mat-button-toggle-button {
+  height: 100%;
+
+  .mat-button-toggle-label-content{
+    height: 100%;
+  }
+}

--- a/frontend/jupyter/src/styles.scss
+++ b/frontend/jupyter/src/styles.scss
@@ -18,7 +18,7 @@ mat-form-field {
 .server-type-wrapper .mat-button-toggle-button {
   height: 100%;
 
-  .mat-button-toggle-label-content{
+  .mat-button-toggle-label-content {
     height: 100%;
   }
 }


### PR DESCRIPTION
for https://github.com/StatCan/jupyter-apis/issues/256

The reason the css change is in the general styles.scss file and not inside the form-image.component.scss that relates directly to this component is because the html elements that needed to be styled are auto-generated by the angular component mat-button-toggle. When specifying the style in the form-image css file, the styling was not being applied.