### PR TITLE
chore(scanning): migrate from azure container scan to trivy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ env:
   KUBECTL_VERSION: 1.21.2
   KUSTOMIZE_VERSION: 4.1.3
   REGISTRY_NAME: k8scc01covidacr
+  TRIVY_VERSION: "v0.43.1"
 
 jobs:
   test:
@@ -59,8 +60,7 @@ jobs:
       run: |
         docker build -f Dockerfile -t ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} .
 
-    - uses: Azure/container-scan@v0
-      with:
-        image-name: ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }}
-        severity-threshold: CRITICAL
-        run-quality-checks: false
+    - name: Aqua Security Trivy image scan
+      run: |
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
+        trivy image ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,6 @@ env:
   KUBECTL_VERSION: 1.21.2
   KUSTOMIZE_VERSION: 4.1.3
   REGISTRY_NAME: k8scc01covidacr
-  TRIVY_VERSION: "v0.43.1"
 
 jobs:
   test:
@@ -55,12 +54,3 @@ jobs:
     - name: Linting
       run: |
         task go:vet
-
-    - name: Build Container
-      run: |
-        docker build -f Dockerfile -t ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} .
-
-    - name: Aqua Security Trivy image scan
-      run: |
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-        trivy image ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,15 +78,15 @@ jobs:
       if: steps.should-i-push.outputs.boolean == 'true'
       run: |
         docker pull localhost:5000/jupyter-apis:${{ github.sha }}
-        docker tag localhost:5000/jupyter-apis:${{ github.sha }} ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }}
-        docker push ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }}
+        docker tag localhost:5000/jupyter-apis:${{ github.sha }} ${{ env.REGISTRY }}.azurecr.io/jupyter-apis:${{ github.sha }}
+        docker push ${{ env.REGISTRY }}.azurecr.io/jupyter-apis:${{ github.sha }}
     
     #- name: Build, Scan, and Push docker image
     #  if: steps.should-i-push.outputs.boolean == 'true'
     #  run: |
     #    docker build -f Dockerfile -t ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }} .
     #    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-    #    trivy image ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
+    #    trivy image ${{ env.REGISTRY}}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
     #    docker push ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }}
 
     #- name: Build and scan docker image
@@ -94,4 +94,4 @@ jobs:
     #  run: |
     #    docker build -f Dockerfile -t ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }} .
     #    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-    #    trivy image ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
+    #    trivy image ${{ env.REGISTRY }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,5 +77,5 @@ jobs:
       if: steps.should-i-push.outputs.boolean == 'true'
       run: |
         docker pull localhost:5000/jupyter-apis:${{ github.sha }}
-        docker tag localhost:5000/jupyter-apis:${{ github.sha }} ${{ env.REGISTRY }}.azurecr.io/jupyter-apis:${{ github.sha }}
-        docker push ${{ env.REGISTRY }}.azurecr.io/jupyter-apis:${{ github.sha }}
+        docker tag localhost:5000/jupyter-apis:${{ github.sha }} ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }}
+        docker push ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,13 +54,16 @@ jobs:
         username: ${{ secrets.DEV_REGISTRY_USERNAME }}
         password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
 
-    - name: Build docker image and push
-      if: steps.should-i-push.outputs.boolean == 'true'
+    - name: Build docker image
       run: |
         docker build -f Dockerfile -t ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }} .
-        docker push ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }}
 
     - name: Aqua Security Trivy image scan
       run: |
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
         trivy image ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
+
+    - name: Push docker image
+      if: steps.should-i-push.outputs.boolean == 'true'
+      run: |
+        docker push ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ on:
 env:
   REGISTRY_NAME: k8scc01covidacr
   DEV_REGISTRY_NAME: k8scc01covidacrdev
+  TRIVY_VERSION: "v0.43.1"
 
 jobs:
   build:
@@ -59,10 +60,7 @@ jobs:
         docker build -f Dockerfile -t ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }} .
         docker push ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }}
 
-    - name: Azure containrer scan
-      if: steps.should-i-push.outputs.boolean == 'true'
-      uses: Azure/container-scan@v0
-      with:
-        image-name: ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }}
-        severity-threshold: CRITICAL
-        run-quality-checks: false
+    - name: Aqua Security Trivy image scan
+      run: |
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
+        trivy image ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Determine if pushing to ACR or DEV ACR
-    - name: Set ENV variables for a PR containing the auto-deploy tag
+    - name: Set ENV variables for a PR
       if: github.event_name == 'pull_request'
       run: echo "REGISTRY=${{env.DEV_REGISTRY_NAME}}.azurecr.io" >> "$GITHUB_ENV"
    

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,16 +54,17 @@ jobs:
         username: ${{ secrets.DEV_REGISTRY_USERNAME }}
         password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
 
-    - name: Build docker image
-      run: |
-        docker build -f Dockerfile -t ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }} .
-
-    - name: Aqua Security Trivy image scan
-      run: |
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-        trivy image ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
-
-    - name: Push docker image
+    - name: Build, Scan, and Push docker image
       if: steps.should-i-push.outputs.boolean == 'true'
       run: |
+        docker build -f Dockerfile -t ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }} .
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
+        trivy image ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity
         docker push ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }}
+
+    - name: Build and scan docker image
+      if: steps.should-i-push.outputs.boolean != 'true'
+      run: |
+        docker build -f Dockerfile -t ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }} .
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
+        trivy image ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,6 @@ jobs:
         password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
 
     
-    # Try the contrib containers way first
     - name: Build image locally
       run: |
         docker build -f Dockerfile -t localhost:5000/jupyter-apis:${{ github.sha }} .
@@ -80,18 +79,3 @@ jobs:
         docker pull localhost:5000/jupyter-apis:${{ github.sha }}
         docker tag localhost:5000/jupyter-apis:${{ github.sha }} ${{ env.REGISTRY }}.azurecr.io/jupyter-apis:${{ github.sha }}
         docker push ${{ env.REGISTRY }}.azurecr.io/jupyter-apis:${{ github.sha }}
-    
-    #- name: Build, Scan, and Push docker image
-    #  if: steps.should-i-push.outputs.boolean == 'true'
-    #  run: |
-    #    docker build -f Dockerfile -t ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }} .
-    #    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-    #    trivy image ${{ env.REGISTRY}}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
-    #    docker push ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }}
-
-    #- name: Build and scan docker image
-    #  if: steps.should-i-push.outputs.boolean != 'true'
-    #  run: |
-    #    docker build -f Dockerfile -t ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }} .
-    #    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-    #    trivy image ${{ env.REGISTRY }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,11 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
     # Determine if pushing to ACR or DEV ACR
     - name: Set ENV variables for a PR
@@ -54,17 +59,39 @@ jobs:
         username: ${{ secrets.DEV_REGISTRY_USERNAME }}
         password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
 
-    - name: Build, Scan, and Push docker image
+    
+    # Try the contrib containers way first
+    - name: Build image locally
+      run: |
+        docker build -f Dockerfile -t localhost:5000/jupyter-apis:${{ github.sha }} .
+        docker push localhost:5000/jupyter-apis:${{ github.sha }}
+        docker rmi localhost:5000/jupyter-apis:${{ github.sha }}
+        docker image prune
+    
+    - name: Aqua Security Trivy image scan
+      run: |
+        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
+        trivy image localhost:5000/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
+    
+    # Container build and push to a Azure Container registry (ACR)
+    - name: Push to ACR if necessary
       if: steps.should-i-push.outputs.boolean == 'true'
       run: |
-        docker build -f Dockerfile -t ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }} .
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-        trivy image ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity
-        docker push ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }}
+        docker pull localhost:5000/jupyter-apis:${{ github.sha }}
+        docker tag localhost:5000/jupyter-apis:${{ github.sha }} ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }}
+        docker push ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }}
+    
+    #- name: Build, Scan, and Push docker image
+    #  if: steps.should-i-push.outputs.boolean == 'true'
+    #  run: |
+    #    docker build -f Dockerfile -t ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }} .
+    #    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
+    #    trivy image ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
+    #    docker push ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }}
 
-    - name: Build and scan docker image
-      if: steps.should-i-push.outputs.boolean != 'true'
-      run: |
-        docker build -f Dockerfile -t ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }} .
-        curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-        trivy image ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity
+    #- name: Build and scan docker image
+    #  if: steps.should-i-push.outputs.boolean != 'true'
+    #  run: |
+    #    docker build -f Dockerfile -t ${{ env.REGISTRY }}/jupyter-apis:${{ github.sha }} .
+    #    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
+    #    trivy image ${{ env.REGISTRY_NAME }}.azurecr.io/jupyter-apis:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     # Determine if pushing to ACR or DEV ACR
     - name: Set ENV variables for a PR containing the auto-deploy tag
-      if: github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'auto-deploy')
+      if: github.event_name == 'pull_request'
       run: echo "REGISTRY=${{env.DEV_REGISTRY_NAME}}.azurecr.io" >> "$GITHUB_ENV"
    
     - name: Set ENV variable for pushes to master


### PR DESCRIPTION
Related to https://github.com/StatCan/aaw-private/issues/112

WIP.
I think the duplication of work that is being seen is because the `build.yml` used to be for PR's and would just build on that, but since we changed our `publish.yml` to also account for PRs with the `auto-deploy` tag (which in the majority of cases we want) it looks like a duplication of work which came from this [pr](https://github.com/StatCan/jupyter-apis/commit/51c6c44b92e752a456719e7c8d2878a06bd750bb) where we added the ability to push to dev acr using the tag.

It wouldn't be a duplication of work if the PR doesnt have the `auto-deploy` tag on, it would just `build`. 
So perhaps a good in-between would be to have the `build.yml` workflow run only if the `auto-deploy` tag isn't on it.