### PR TITLE
fix: sas default tag

### DIFF
--- a/frontend/jupyter/cypress/fixtures/config.json
+++ b/frontend/jupyter/cypress/fixtures/config.json
@@ -36,9 +36,9 @@
               "state.aaw.statcan.gc.ca/exists-non-sas-notebook-user":"false"
            }
         },
-        "value":"k8scc01covidacr.azurecr.io/sas:latest",
+        "value":"k8scc01covidacr.azurecr.io/sas:v1",
         "options":[
-           "k8scc01covidacr.azurecr.io/sas:latest"
+           "k8scc01covidacr.azurecr.io/sas:v1"
         ]
      },
      "allowCustomImage":true,

--- a/samples/spawner_ui_config.yaml
+++ b/samples/spawner_ui_config.yaml
@@ -55,9 +55,9 @@ spawnerFormDefaults:
     disabledMessage:
       en: "SAS is unavailable while non-employees have access to this profile."
       fr: "SAS n'est pas disponible lorsque des non-employés ont accès à ce profil."
-    value: k8scc01covidacr.azurecr.io/sas:latest    # The list of available standard container Images
+    value: k8scc01covidacr.azurecr.io/sas:v1    # The list of available standard container Images
     options:
-    - k8scc01covidacr.azurecr.io/sas:latest
+    - k8scc01covidacr.azurecr.io/sas:v1
   hideRegistry: true
   hideTag: true
   allowCustomImage: true


### PR DESCRIPTION
The SAS default tag is `latest`, when it should be `v1`. `latest` is shared with the Zone, and `v1` is for AAW exclusively. 

This means that the image pulled isn't stable or reliably using the AAW image. 

