### PR TITLE
fix(notebooks.go): transform condition messages

### DIFF
--- a/notebooks.go
+++ b/notebooks.go
@@ -1100,12 +1100,9 @@ func (s *server) GetNotebookEvents(w http.ResponseWriter, r *http.Request) {
 // getUserFriendlyMessage returns a user‑friendly message for a NotebookCondition.
 // If no mapping is found, it falls back to condition.Message.
 func getUserFriendlyMessage(condition *kubeflowv1.NotebookCondition) string {
-	switch condition.Type {
-	case "PodScheduled":
-		switch condition.Reason {
-		case "Unschedulable":
-			return "Please wait 30 seconds before trying again (unable to schedule notebook)."
-		}
+	// NOTE: Use switch case statements if this function grows to account for other condition types and condition reason
+	if condition.Type == "PodScheduled" && condition.Reason == "Unschedulable" {
+		return "Please wait 30 seconds before trying again (unable to schedule notebook)."
 	}
 	return condition.Message // fallback to original
 }

--- a/notebooks.go
+++ b/notebooks.go
@@ -1104,7 +1104,7 @@ func getUserFriendlyMessage(condition *kubeflowv1.NotebookCondition) string {
 	case "PodScheduled":
 		switch condition.Reason {
 		case "Unschedulable":
-			return "Please Wait 30 Seconds before trying again (Unable to schedule notebook)"
+			return "Please wait 30 seconds before trying again (unable to schedule notebook)."
 		}
 	}
 	return condition.Message // fallback to original

--- a/notebooks.go
+++ b/notebooks.go
@@ -972,6 +972,12 @@ func (s *server) GetNotebook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Changing Notebook Condition Message to Something User Friendly
+	status := &nb.Status
+	for i := range status.Conditions {
+		status.Conditions[i].Message = getUserFriendlyMessage(&status.Conditions[i])
+	}
+
 	resp := &getnotebookresponse{
 		APIResponseBase: APIResponseBase{
 			Success: true,
@@ -1089,4 +1095,17 @@ func (s *server) GetNotebookEvents(w http.ResponseWriter, r *http.Request) {
 		Events: events.Items,
 	}
 	s.respond(w, r, resp)
+}
+
+// getUserFriendlyMessage returns a user‑friendly message for a NotebookCondition.
+// If no mapping is found, it falls back to condition.Message.
+func getUserFriendlyMessage(condition *kubeflowv1.NotebookCondition) string {
+	switch condition.Type {
+	case "PodScheduled":
+		switch condition.Reason {
+		case "Unschedulable":
+			return "Please Wait 30 Seconds before trying again (Unable to schedule notebook)"
+		}
+	}
+	return condition.Message // fallback to original
 }


### PR DESCRIPTION
### Proposed Changes/Description 

Former condition messages in the notebook condition tables were very technical and unhelpful for the end user, this change provides a new function to transform the messages to user friendly ones, otherwise, it falls back to the default message provided by the k8s api.

Details about Notebook Conditions can be found here: https://www.kubeflow.org/docs/components/notebooks/api-reference/notebook-v1/#kubeflow.org/v1.NotebookCondition

NOTE: This ticket does not add friendly error message, it provides a feature (translate function) to turn technical messages into end user friendly ones.

### Screenshots

Before: 
<img width="424" height="170" alt="image" src="https://github.com/user-attachments/assets/12f88d0c-50a0-44c8-adea-30b25cfefd2b" />

After: 
<img width="2542" height="302" alt="image" src="https://github.com/user-attachments/assets/e175804c-fbe0-4009-9c59-03bfaebf8f7f" />

### Testing

Create a Notebook with high allocated resources (ie lots of ram and cpu), when the notebook errors, click on it and check the message like you can see below:

<img width="2547" height="1334" alt="image" src="https://github.com/user-attachments/assets/b06ec8c7-5081-429f-89ee-c06ec60023bc" />


### Types of Changes

What types of changes does your code introduce to volume-cleaner? Put an `x` in the boxes that apply 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update 
- [x] Other (if none of the other choices apply)

### Related Issue/Ticket

https://jirab.statcan.ca/browse/ZONE-100

