### PR TITLE
fix(notebooks.go): Backend POST request Input Validation for new notebook creation

### DIFF
--- a/notebooks.go
+++ b/notebooks.go
@@ -1123,7 +1123,7 @@ func validateNotebook(request newnotebookrequest) error {
 	if request.Name == "" {
 		validationErrors = append(validationErrors, "name is required")
 	} else {
-		// Kubernetes naming validation for notebook name
+		// K8s naming validation for notebook name
 		// NOTE: regular expression ensures the input consists of lowercase alphanumeric characters or '-', start/end with an alphabetic character
 		matched, err := regexp.MatchString(`^[a-z]([-a-z0-9]*[a-z0-9])?$`, request.Name)
 		if err != nil {


### PR DESCRIPTION
### Proposed Changes/Description 

When the frontend makes a post request to the Golang backend requesting the creation of a new notebook, the form input for a new notebook is validated on the angular central dashboard end but isn't validated on the backend. This new feature add validation for the newnotebookrequest struct

<img width="524" height="446" alt="image" src="https://github.com/user-attachments/assets/ff6d2c00-76fb-43f7-aea8-b3b31ddb608c" />

NOTE: Notebook update validation is not checked since the updatenotebookrequest type is just a single boolean (there is not much to check)

<img width="320" height="78" alt="image" src="https://github.com/user-attachments/assets/44efbf4f-e02c-43d1-b722-2595acc215bb" />

### Types of Changes

What types of changes does your code introduce to jupyter-apis? Put an `x` in the boxes that apply 

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update 
- [x] Other (if none of the other choices apply)

### Related Issue/Ticket

https://jirab.statcan.ca/browse/ZONE-96

### Screenshots

After Implementation Example:
<img width="816" height="871" alt="image" src="https://github.com/user-attachments/assets/7b66d8d2-9d4c-47f2-af3e-0b8dae03b10b" />

