### PR TITLE
fix: change server type check from two to three (SAS Image)

### DIFF
--- a/notebooks.go
+++ b/notebooks.go
@@ -1163,7 +1163,7 @@ func validateNotebook(request newnotebookrequest) error {
 	}
 
 	// Fix ServerType validation to match actual system values
-	validServerTypes := map[string]bool{"jupyter": true, "group-two": true}
+	validServerTypes := map[string]bool{"jupyter": true, "group-three": true}
 	if request.ServerType != "" && !validServerTypes[request.ServerType] {
 		validationErrors = append(validationErrors, "invalid ServerType: "+request.ServerType)
 	}


### PR DESCRIPTION
### Proposed Changes/Description 

When the frontend makes a post request to the Golang backend requesting the creation of a new notebook, the form input for a new notebook is validated on the angular central dashboard end but isn't validated on the backend. This new feature add validation for the newnotebookrequest struct, **this change is just a hot-fix to pass validation for SAS images**

### Types of Changes

What types of changes does your code introduce to volume-cleaner? Put an `x` in the boxes that apply 

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update 
- [ ] Other (if none of the other choices apply)

### Related Issue/Ticket

https://jirab.statcan.ca/browse/ZONE-96
