### PR TITLE
feat: add OneLake notebook checkbox

### DIFF
--- a/frontend/jupyter/cypress/e2e/form-page.cy.ts
+++ b/frontend/jupyter/cypress/e2e/form-page.cy.ts
@@ -485,5 +485,28 @@ describe('New notebook form', () => {
       cy.wait('@mockSubmitNotebook');
       cy.url().should('eq', 'http://localhost:4200/');
     });
+
+    it('should create a OneLake notebook', ()=>{
+      cy.get('lib-name-input[resourcename="Notebook Server"]').find('input').type('test-notebook-onelake');
+      cy.get('[data-cy-advanced-options-button]').click();
+      cy.get('[data-cy-form-input="onelakeCheck"]').find('input').check({force: true});
+      cy.get('[data-cy-form-input="onelakeWorkspace"]').find('input').type('workspace-guid');
+      cy.get('[data-cy-form-input="onelakeLakehouse"]').find('input').type('lakehouse-guid');
+      // submit the notebook
+      cy.get('[data-cy-form-button="submit"]').should('be.enabled');
+      cy.intercept('POST', 'api/namespaces/kubeflow-user/notebooks', req => {
+        expect(req.body.configurations).to.include('onelake-fuse');
+        expect(req.body.onelake).to.eq(true);
+        expect(req.body.onelakeWorkspace).to.eq('workspace-guid');
+        expect(req.body.onelakeLakehouse).to.eq('lakehouse-guid');
+        req.reply({
+          success: true,
+          status: 200
+        });
+      }).as('mockSubmitNotebook');
+      cy.get('[data-cy-form-button="submit"]').click();
+      cy.wait('@mockSubmitNotebook');
+      cy.url().should('eq', 'http://localhost:4200/');
+    });
   });
 });

--- a/frontend/jupyter/src/app/pages/form/form-new/form-image-custom/form-image-custom.component.html
+++ b/frontend/jupyter/src/app/pages/form/form-new/form-image-custom/form-image-custom.component.html
@@ -93,15 +93,57 @@
     </mat-form-field>
 
     <div class="flex-column">
-      <mat-checkbox
-        *ngIf="allowCustomImage"
-        [formControl]="parentForm.get('customImageCheck')"
-        (change)="onSelect($event)"
-        i18n
-        data-cy-form-input="customImageCheck"
-      >
-        Custom Image
-      </mat-checkbox>
+      <div class="image-option-row">
+        <mat-checkbox
+          *ngIf="allowCustomImage"
+          [formControl]="parentForm.get('customImageCheck')"
+          (change)="onSelect($event)"
+          i18n
+          data-cy-form-input="customImageCheck"
+        >
+          Custom Image
+        </mat-checkbox>
+
+        <mat-checkbox
+          [formControl]="parentForm.get('onelake')"
+          i18n
+          data-cy-form-input="onelakeCheck"
+        >
+          OneLake
+        </mat-checkbox>
+      </div>
+
+      <div class="onelake-fields" *ngIf="parentForm?.value.onelake">
+        <mat-form-field
+          class="wide"
+          appearance="outline"
+          data-cy-form-input="onelakeWorkspace"
+        >
+          <mat-label i18n>OneLake workspace</mat-label>
+          <input
+            matInput
+            placeholder="Workspace name or GUID"
+            i18n-placeholder
+            [formControl]="parentForm.get('onelakeWorkspace')"
+          />
+          <mat-error i18n>Workspace is required</mat-error>
+        </mat-form-field>
+
+        <mat-form-field
+          class="wide"
+          appearance="outline"
+          data-cy-form-input="onelakeLakehouse"
+        >
+          <mat-label i18n>OneLake lakehouse</mat-label>
+          <input
+            matInput
+            placeholder="Lakehouse name or GUID"
+            i18n-placeholder
+            [formControl]="parentForm.get('onelakeLakehouse')"
+          />
+          <mat-error i18n>Lakehouse is required</mat-error>
+        </mat-form-field>
+      </div>
 
       <mat-form-field
         class="wide"

--- a/frontend/jupyter/src/app/pages/form/form-new/form-image-custom/form-image-custom.component.scss
+++ b/frontend/jupyter/src/app/pages/form/form-new/form-image-custom/form-image-custom.component.scss
@@ -1,0 +1,11 @@
+.image-option-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.onelake-fields {
+  margin-top: 0.5rem;
+}

--- a/frontend/jupyter/src/app/pages/form/form-new/form-image-custom/form-image-custom.component.spec.ts
+++ b/frontend/jupyter/src/app/pages/form/form-new/form-image-custom/form-image-custom.component.spec.ts
@@ -48,6 +48,9 @@ describe('FormImageCustomComponent', () => {
       imageGroupOne: new FormControl(),
       imageGroupTwo: new FormControl(),
       imageGroupThree: new FormControl(),
+      onelake: new FormControl(),
+      onelakeWorkspace: new FormControl(),
+      onelakeLakehouse: new FormControl(),
     });
 
     fixture.detectChanges();

--- a/frontend/jupyter/src/app/pages/form/form-new/form-new.component.spec.ts
+++ b/frontend/jupyter/src/app/pages/form/form-new/form-new.component.spec.ts
@@ -18,8 +18,10 @@ import { FormCpuRamModule } from './form-cpu-ram/form-cpu-ram.module';
 import { FormDataVolumesModule } from './form-data-volumes/form-data-volumes.module';
 import { FormGpusModule } from './form-gpus/form-gpus.module';
 import { FormImageModule } from './form-image/form-image.module';
+import { FormImageCustomModule } from './form-image-custom/form-image-custom.module';
 import { FormNameModule } from './form-name/form-name.module';
 import { FormNewComponent } from './form-new.component';
+import { FormProtectedBModule } from './form-protected-b/form-protected-b.module';
 import { FormWorkspaceVolumeModule } from './form-workspace-volume/form-workspace-volume.module';
 import { VolumeModule } from './volume/volume.module';
 
@@ -61,7 +63,9 @@ describe('FormNewComponent', () => {
         FormAffinityTolerationsModule,
         FormAdvancedOptionsModule,
         FormImageModule,
+        FormImageCustomModule,
         FormNameModule,
+        FormProtectedBModule,
         HttpClientModule,
         RouterTestingModule,
         NoopAnimationsModule,
@@ -82,5 +86,28 @@ describe('FormNewComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should add the OneLake configuration when selected', () => {
+    component.formCtrl.patchValue({
+      name: 'test-notebook',
+      namespace: 'kubeflow-user',
+      image: 'registry/jupyterlab-cpu:latest',
+      cpu: 1,
+      cpuLimit: 1,
+      memory: 1,
+      memoryLimit: 1,
+      configurations: [],
+      onelake: true,
+      onelakeWorkspace: ' workspace-guid ',
+      onelakeLakehouse: ' lakehouse-guid ',
+    });
+
+    const notebook = component.getSubmitNotebook();
+
+    expect(notebook.configurations).toContain('onelake-fuse');
+    expect(notebook.onelake).toBeTrue();
+    expect(notebook.onelakeWorkspace).toBe('workspace-guid');
+    expect(notebook.onelakeLakehouse).toBe('lakehouse-guid');
   });
 });

--- a/frontend/jupyter/src/app/pages/form/form-new/form-new.component.ts
+++ b/frontend/jupyter/src/app/pages/form/form-new/form-new.component.ts
@@ -5,12 +5,16 @@ import {
   ChangeDetectorRef,
   AfterContentChecked,
 } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, Validators } from '@angular/forms';
 import { Config, NotebookFormObject } from 'src/app/types';
 import { Subscription } from 'rxjs';
 import { NamespaceService, SnackBarService, SnackType } from 'kubeflow';
 import { Router } from '@angular/router';
-import { getFormDefaults, initFormControls } from './utils';
+import {
+  getFormDefaults,
+  initFormControls,
+  ONELAKE_CONFIGURATION_LABEL,
+} from './utils';
 import { JWABackendService } from 'src/app/services/backend.service';
 import { V1Namespace } from '@kubernetes/client-node';
 
@@ -37,6 +41,8 @@ export class FormNewComponent
   existingNotebooks: Set<string> = new Set<string>();
   mountedVolumes: Set<string> = new Set<string>();
 
+  private readonly onelakeConfigurationLabel = ONELAKE_CONFIGURATION_LABEL;
+
   constructor(
     public namespaceService: NamespaceService,
     public backend: JWABackendService,
@@ -48,6 +54,8 @@ export class FormNewComponent
   ngOnInit(): void {
     // Initialize the form control
     this.formCtrl = this.getFormDefaults();
+
+    this.subscribeToOnelakeControl();
 
     // Update the form Values from the default ones
     this.backend.getConfig().subscribe(config => {
@@ -121,6 +129,56 @@ export class FormNewComponent
     this.cdr.detectChanges();
   }
 
+  private subscribeToOnelakeControl(): void {
+    this.subscriptions.add(
+      this.formCtrl.get('onelake').valueChanges.subscribe(enabled => {
+        this.setOnelakeConfiguration(enabled);
+        this.setOnelakeFieldValidators(enabled);
+      }),
+    );
+
+    this.subscriptions.add(
+      this.formCtrl.get('configurations').valueChanges.subscribe(configs => {
+        const enabled = Array.isArray(configs)
+          ? configs.includes(this.onelakeConfigurationLabel)
+          : false;
+        const onelakeControl = this.formCtrl.get('onelake');
+
+        if (onelakeControl.value !== enabled) {
+          onelakeControl.setValue(enabled, { emitEvent: false });
+          this.setOnelakeFieldValidators(enabled);
+        }
+      }),
+    );
+  }
+
+  private setOnelakeFieldValidators(enabled: boolean): void {
+    for (const controlName of ['onelakeWorkspace', 'onelakeLakehouse']) {
+      const control = this.formCtrl.get(controlName);
+      if (enabled) {
+        control.setValidators([Validators.required]);
+      } else {
+        control.clearValidators();
+        control.setValue('', { emitEvent: false });
+      }
+      control.updateValueAndValidity({ emitEvent: false });
+    }
+  }
+
+  private setOnelakeConfiguration(enabled: boolean): void {
+    const configurationsControl = this.formCtrl.get('configurations');
+    const current = Array.isArray(configurationsControl.value)
+      ? configurationsControl.value
+      : [];
+    const next = current.filter(
+      config => config !== this.onelakeConfigurationLabel,
+    );
+
+    configurationsControl.setValue(
+      enabled ? [...next, this.onelakeConfigurationLabel] : next,
+    );
+  }
+
   initFormControls(formCtrl: FormGroup, config: Config) {
     initFormControls(formCtrl, config);
   }
@@ -128,6 +186,7 @@ export class FormNewComponent
   // Form Actions
   getSubmitNotebook(): NotebookFormObject {
     const notebookCopy = this.formCtrl.value as NotebookFormObject;
+    const onelakeEnabled = notebookCopy.onelake;
     const notebook = JSON.parse(JSON.stringify(notebookCopy));
 
     // Use the custom image instead
@@ -197,6 +256,20 @@ export class FormNewComponent
       if (vol.size) {
         vol.size = vol.size + 'Gi';
       }
+    }
+
+    if (onelakeEnabled) {
+      notebook.onelakeWorkspace = notebook.onelakeWorkspace?.trim();
+      notebook.onelakeLakehouse = notebook.onelakeLakehouse?.trim();
+      notebook.configurations = Array.isArray(notebook.configurations)
+        ? notebook.configurations
+        : [];
+      if (!notebook.configurations.includes(this.onelakeConfigurationLabel)) {
+        notebook.configurations.push(this.onelakeConfigurationLabel);
+      }
+    } else {
+      delete notebook.onelakeWorkspace;
+      delete notebook.onelakeLakehouse;
     }
 
     return notebook;

--- a/frontend/jupyter/src/app/pages/form/form-new/utils.ts
+++ b/frontend/jupyter/src/app/pages/form/form-new/utils.ts
@@ -2,6 +2,8 @@ import { FormBuilder, FormGroup, Validators, FormArray } from '@angular/forms';
 import { GPU, Config } from 'src/app/types';
 import { createFormGroupFromVolume } from 'src/app/shared/utils/volumes';
 
+export const ONELAKE_CONFIGURATION_LABEL = 'onelake-fuse';
+
 export function getFormDefaults(): FormGroup {
   const fb = new FormBuilder();
 
@@ -47,6 +49,9 @@ export function getFormDefaults(): FormGroup {
     shm: [true, []],
     configurations: [[], []],
     prob: [false, []],
+    onelake: [false, []],
+    onelakeWorkspace: ['', []],
+    onelakeLakehouse: ['', []],
     language: ['', [Validators.required]],
   });
 }
@@ -182,6 +187,9 @@ export function initFormControls(formCtrl: FormGroup, config: Config) {
   if (config.configurations.readOnly) {
     formCtrl.controls.configurations.disable();
   }
+  formCtrl.controls.onelake.setValue(
+    config.configurations.value?.includes(ONELAKE_CONFIGURATION_LABEL) ?? false,
+  );
 }
 
 export function initWorkspaceVolumeControl(form: FormGroup, config: Config) {

--- a/frontend/jupyter/src/app/types/notebook.ts
+++ b/frontend/jupyter/src/app/types/notebook.ts
@@ -1,5 +1,4 @@
 import { Status } from 'kubeflow';
-import { PodDefault } from './poddefault';
 import { GPU } from './gpu';
 import {
   V1ContainerState,
@@ -66,7 +65,10 @@ export interface NotebookFormObject {
   workspace: any;
   datavols: any[];
   shm: boolean;
-  configurations: PodDefault[];
+  onelake?: boolean;
+  onelakeWorkspace?: string;
+  onelakeLakehouse?: string;
+  configurations: string[];
 }
 
 export interface NotebookRawObject {

--- a/notebooks.go
+++ b/notebooks.go
@@ -103,6 +103,9 @@ type newnotebookrequest struct {
 	DataVolumes        []volrequest      `json:"datavols"`
 	EnableSharedMemory bool              `json:"shm"`
 	Configurations     []string          `json:"configurations"`
+	Onelake            bool              `json:"onelake"`
+	OnelakeWorkspace   string            `json:"onelakeWorkspace"`
+	OnelakeLakehouse   string            `json:"onelakeLakehouse"`
 	Protb              bool              `json:"prob"`
 	Language           string            `json:"language"`
 	ImagePullPolicy    string            `json:"imagePullPolicy"`
@@ -538,6 +541,15 @@ func (s *server) NewNotebook(w http.ResponseWriter, r *http.Request) {
 	// AAW Customization Adding protected B
 	if req.Protb {
 		notebook.ObjectMeta.Labels["notebook.statcan.gc.ca/protected-b"] = "true"
+	}
+
+	// Add OneLake configuration
+	if req.Onelake {
+		notebook.ObjectMeta.Labels["onelake-fuse"] = "true"
+		notebook.Spec.Template.Spec.Containers[0].Env = append(notebook.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{Name: "ONELAKE_WORKSPACE", Value: strings.TrimSpace(req.OnelakeWorkspace)},
+			corev1.EnvVar{Name: "ONELAKE_LAKEHOUSE", Value: strings.TrimSpace(req.OnelakeLakehouse)},
+		)
 	}
 
 	// Add configuration items


### PR DESCRIPTION
Adds a OneLake checkbox to the notebook launcher and sends the existing onelake-fuse PodDefault label through configurations when selected.\n\nTested:\n- git diff --check\n\nNot run locally: Angular/Go test suites; Node, npm, Go, and Docker are not installed in this shell.