### PR TITLE
chore(backend): created utils function to read request body into struct

### DIFF
--- a/httputils.go
+++ b/httputils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
 )
@@ -67,4 +68,20 @@ func (s *server) error(w http.ResponseWriter, r *http.Request, err error) {
 		Status:  http.StatusInternalServerError,
 		Log:     err.Error(),
 	})
+}
+
+// handles reading a request body and unmarshalling to a struct
+func (s *server) readRequestBody(w http.ResponseWriter, r *http.Request, object interface{}) error {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	defer r.Body.Close()
+
+	err = json.Unmarshal(body, object)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/notebooks.go
+++ b/notebooks.go
@@ -46,6 +46,7 @@ const AutoMountLabel string = "data.statcan.gc.ca/inject-blob-volumes"
 
 // LastActivityAnnotation is the annotation name for the last activity value.
 const LastActivityAnnotation = "notebooks.kubeflow.org/last-activity"
+
 // LastActivityCheckTimeStamp for the delay shutdown
 const LastActivityCheckTimeStamp = "notebooks.kubeflow.org/last_activity_check_timestamp"
 
@@ -593,15 +594,8 @@ func (s *server) NewNotebook(w http.ResponseWriter, r *http.Request) {
 	namespace := vars["namespace"]
 
 	// Read the incoming notebook
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		s.error(w, r, err)
-		return
-	}
-	defer r.Body.Close()
-
 	var req newnotebookrequest
-	err = json.Unmarshal(body, &req)
+	err := s.readRequestBody(w, r, &req)
 	if err != nil {
 		s.error(w, r, err)
 		return
@@ -902,15 +896,8 @@ func (s *server) StartStopNotebook(w http.ResponseWriter, r *http.Request) {
 	log.Printf("patching notebook %q for %q", notebookName, namespaceName)
 
 	// Read the incoming notebook
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		s.error(w, r, err)
-		return
-	}
-	defer r.Body.Close()
-
 	var req startstopnotebookrequest
-	err = json.Unmarshal(body, &req)
+	err := s.readRequestBody(w, r, &req)
 	if err != nil {
 		s.error(w, r, err)
 		return
@@ -963,15 +950,8 @@ func (s *server) UpdateNotebook(w http.ResponseWriter, r *http.Request) {
 	notebookName := vars["notebook"]
 
 	// Read the incoming notebook
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		s.error(w, r, err)
-		return
-	}
-	defer r.Body.Close()
-
 	var req updatenotebookrequest
-	err = json.Unmarshal(body, &req)
+	err := s.readRequestBody(w, r, &req)
 	if err != nil {
 		s.error(w, r, err)
 		return
@@ -1059,15 +1039,8 @@ func (s *server) UpdateNotebookForCulling(w http.ResponseWriter, r *http.Request
 	log.Printf("updating notebook %q for %q with additional time", notebookName, namespaceName)
 
 	// Read the incoming notebook
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		s.error(w, r, err)
-		return
-	}
-	defer r.Body.Close()
-	//json object so make it a sturct
 	var req delaycullingrequest
-	err = json.Unmarshal(body, &req)
+	err := s.readRequestBody(w, r, &req)
 	if err != nil {
 		s.error(w, r, err)
 		return
@@ -1100,14 +1073,14 @@ func (s *server) UpdateNotebookForCulling(w http.ResponseWriter, r *http.Request
 
 	notebook.Annotations[LastActivityAnnotation] = updatedTime.Format(time.RFC3339)
 	notebook.Annotations[LastActivityCheckTimeStamp] = updatedTime.Format(time.RFC3339)
-	 
+
 	_, err = s.clientsets.kubeflow.KubeflowV1().Notebooks(namespaceName).Update(r.Context(), notebook, metav1.UpdateOptions{})
 	if err != nil {
 		s.error(w, r, err)
 		return
 	}
 
-	log.Printf("Updated notebook %q with time %q", notebookName, updatedTime);
+	log.Printf("Updated notebook %q with time %q", notebookName, updatedTime)
 
 	s.respond(w, r, &APIResponseBase{
 		Success: true,
@@ -1492,7 +1465,7 @@ func validateNotebookVolume(req volrequest, validsizes map[int64]bool) error {
 }
 
 func validateCullingDelay(delayHours int) error {
-	if (delayHours < 1 || delayHours > 72){
+	if delayHours < 1 || delayHours > 72 {
 		return fmt.Errorf("validation failed: the delay must be between 1 and 72.")
 	}
 

--- a/persistentvolumeclaims.go
+++ b/persistentvolumeclaims.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"sort"
@@ -387,15 +386,8 @@ func (s *server) UpdatePersistentVolumeClaimsUsage(w http.ResponseWriter, r *htt
 	namespace := vars["namespace"]
 
 	// Read the incoming usage data
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		s.error(w, r, err)
-		return
-	}
-	defer r.Body.Close()
-
 	var req pvcsusagedata
-	err = json.Unmarshal(body, &req)
+	err := s.readRequestBody(w, r, &req)
 	if err != nil {
 		s.error(w, r, err)
 		return

--- a/rest-tests/restclient.http
+++ b/rest-tests/restclient.http
@@ -78,7 +78,15 @@ PATCH {{BASE_URL}}/namespaces/{{KF_NAMESPACE}}/notebooks/{{KF_NOTEBOOK_NAME_PATC
 kubeflow-userid: {{KF_USER_ID}}
 
 {
-    "stopped": true
+    "stopped": false
+}
+
+### Postpone Culling
+PATCH {{BASE_URL}}/namespaces/{{KF_NAMESPACE}}/notebooks/{{KF_NOTEBOOK_NAME_PATCH}}/keepalive
+kubeflow-userid: {{KF_USER_ID}}
+
+{
+    "timehours": "2"
 }
 
 ### Updates a notebook
@@ -157,11 +165,4 @@ Content-Type: application/json
 kubeflow-userid: {{KF_USER_ID}}
 {
     "name": "{{KF_PVC_VIEWER_NAME_CREATE}}"
-}
-
-### Postpone Culling
-PATCH {{BASE_URL}}/namespaces/{{KF_NAMESPACE}}/notebooks/{{KF_NOTEBOOK_NAME_PATCH}}/keepalive}
-kubeflow-userid: {{KF_USER_ID}}
-{
-    "timehours": 2
 }

--- a/viewer.go
+++ b/viewer.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
@@ -206,17 +205,8 @@ func (s *server) PostPvcViewer(w http.ResponseWriter, r *http.Request) {
 	namespace := vars["namespace"]
 
 	// Read the incoming notebook
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		s.error(w, r, err)
-		return
-	}
-	defer r.Body.Close()
-
-	log.Printf("received viewer body %s for namespace %s", body, namespace)
-
 	var req pvcviewerrequest
-	err = json.Unmarshal(body, &req)
+	err := s.readRequestBody(w, r, &req)
 	if err != nil {
 		s.error(w, r, err)
 		return


### PR DESCRIPTION
This cleanup is to reduce some code duplication.

We had repeated usage of code to read a request body, and unmarshall it into a struct. This groups all that up into 1 function.